### PR TITLE
Don't use Write::write_all

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ mod tests;
 /// See the [crate level documentation] for more.
 ///
 /// [crate level documentation]: index.html#logging-requests
-pub const REQUEST_TARGET: &'static str = "request";
+pub const REQUEST_TARGET: &str = "request";
 
 /// Initialise the logger.
 ///
@@ -368,8 +368,8 @@ fn stderr() -> io::Stderr {
 
 #[cfg(test)]
 mod test_instruments {
-    use std::ptr::null_mut;
     use std::io::{self, Write};
+    use std::ptr::null_mut;
     use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 
     // TODO: replace `LOG_OUTPUT` with type `[Option<Vec<u8>>; 10]`, once the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,9 +194,6 @@
         variant_size_differences,
 )]
 
-#[cfg(test)]
-mod tests;
-
 use std::cell::RefCell;
 use std::env;
 use std::io::{self, Write};
@@ -205,6 +202,9 @@ use log::{LevelFilter, Log, Metadata, Record, SetLoggerError};
 
 #[cfg(feature = "timestamp")]
 use chrono::{Datelike, Timelike};
+
+#[cfg(test)]
+mod tests;
 
 /// Target for logging requests.
 ///
@@ -287,7 +287,7 @@ impl Log for Logger {
 /// The actual logging of a record.
 fn log(record: &Record) {
     // Thread local buffer for `log`. This way we only lock standard out/error
-    // for a single write call and create half writes.
+    // for a single write call and don't create half written logs.
     thread_local! {
         static BUFFER: RefCell<Vec<u8>> = RefCell::new(Vec::new());
     }


### PR DESCRIPTION
Write_all will write in a loop, meaning that if the first write is partial it will write the remaining buffer again. But we don't want that as that will result in half written logs, which are less the readable.