### PR TITLE
Change to logfmt format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ nightly  = []
 
 [dependencies]
 log        = { version = "0.4.14", default-features = false, features = ["kv_unstable_std"] }
+itoa       = { version = "0.4.7", default-features = false }
+ryu        = { version = "1.0.5", default-features = false }
 # Required by timestamp feature.
 libc       = { version = "0.2.86", optional = true, default-features = false }
 # Required by log-panic feature.

--- a/examples/key_value.rs
+++ b/examples/key_value.rs
@@ -28,7 +28,7 @@ fn logger_middleware(request: Request) -> Response {
     // Clone the url and method. Note: don't actually do this in an HTTP this is
     // rather wastefull to.
     let url = request.url.clone();
-    let method = request.url.clone();
+    let method = request.method.clone();
 
     // Call our handler.
     let response = http_handler(request);

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,55 +1,167 @@
 use std::fmt;
+use std::io::IoSlice;
 use std::io::Write;
 
 use log::{kv, Record};
 
-use crate::REQUEST_TARGET;
+/// Number of buffers the [`record`] function requires.
+pub(crate) const BUFS_SIZE: usize = 11;
 
-/// Formats `record`, writing into `buf`.
-#[inline(always)]
-pub(crate) fn record(buf: &mut Vec<u8>, record: &Record, debug: bool) {
+/// Formats a log `record`.
+///
+/// This writes into the buffer `buf` for things that need formatting, which it
+/// resets itself. The returned slices is based on `bufs`, which is used to
+/// order the writable buffers.
+///
+/// If `debug` is `true` the file and line are added.
+#[inline]
+pub(crate) fn record<'b>(
+    bufs: &'b mut [IoSlice<'b>; BUFS_SIZE],
+    buf: &'b mut Buffer,
+    record: &'b Record,
+    debug: bool,
+) -> &'b [IoSlice<'b>] {
+    // Write all parts of the buffer that need formatting.
     #[cfg(feature = "timestamp")]
-    format_timestamp(buf);
-
-    match record.target() {
-        REQUEST_TARGET => {
-            buf.extend_from_slice(b"[REQUEST] ");
-            buf.extend_from_slice(record.module_path().unwrap_or("").as_bytes())
-        }
-        target => {
-            buf.push(b'[');
-            // TODO: replace with `Level::as_str`.
-            write!(buf, "{}", record.level()).unwrap_or_else(|_| unreachable!());
-            buf.push(b']');
-            buf.push(b' ');
-            buf.extend_from_slice(target.as_bytes());
-        }
-    }
-
+    buf.write_ts();
+    buf.write_msg(record.args());
+    buf.write_key_values(record.key_values());
     if debug {
-        write!(
-            buf,
-            " ({}:{})",
-            record.file().unwrap_or("??"),
-            record.line().unwrap_or(0),
-        )
-        .unwrap_or_else(|_| unreachable!());
+        buf.write_line(record.line().unwrap_or(0));
     }
 
-    buf.push(b':');
-    buf.push(b' ');
-    writeln!(
-        buf,
-        "{}{}",
-        record.args(),
-        KeyValuePrinter(record.key_values())
-    )
-    .unwrap_or_else(|_| unreachable!());
+    // Now that we've written the message to our buffer we have to construct it.
+    // The first part of the message is the timestamp and log level, e.g.
+    // `ts="2020-12-31T12:32:23.906132Z" lvl="INFO`.
+    // Or without a timestamp, i.e. `lvl="INFO`.
+    bufs[0] = IoSlice::new(buf.ts());
+    bufs[1] = IoSlice::new(record.level().as_str().as_bytes());
+    // The message (and the end of the log level), e.g. `" msg="some message`.
+    bufs[2] = IoSlice::new(buf.msg());
+    // The target, e.g. `" target="request`.
+    bufs[3] = IoSlice::new(b"\" target=\"");
+    bufs[4] = IoSlice::new(record.target().as_bytes());
+    // The module, e.g. `" module="stored::http`.
+    bufs[5] = IoSlice::new(b"\" module=\"");
+    bufs[6] = IoSlice::new(record.module_path().unwrap_or("").as_bytes());
+    // Any key value pairs supplied by the user.
+    bufs[7] = IoSlice::new(buf.key_values());
+    // Optional file, e.g. ` file="some_file:123"`, and a line end.
+    let n = if debug {
+        bufs[8] = IoSlice::new(b" file=\"");
+        bufs[9] = IoSlice::new(record.file().unwrap_or("??").as_bytes());
+        bufs[10] = IoSlice::new(buf.line());
+        BUFS_SIZE
+    } else {
+        bufs[8] = IoSlice::new(b"\n");
+        BUFS_SIZE - 2
+    };
+
+    &bufs[..n]
 }
 
+/// Number of indices used in `Buffer`:
+/// 0) Message.
+/// 1) Key value pairs.
+/// 2) File line.
+const N_INDICES: usize = 3;
+
+/// Parts of the message we can reuse.
 #[cfg(feature = "timestamp")]
-#[inline(always)]
-fn format_timestamp(buf: &mut Vec<u8>) {
+const REUSABLE_PARTS: &[u8] = b"ts=\"0000-00-00T00:00:00.000000Z\" lvl=\"\" msg=\"";
+#[cfg(not(feature = "timestamp"))]
+const REUSABLE_PARTS: &[u8] = b"lvl=\"\" msg=\"";
+
+/// Index of the end of `ts="..." lvl="`.
+#[cfg(feature = "timestamp")]
+const TS_END_INDEX: usize = 38;
+#[cfg(not(feature = "timestamp"))]
+const TS_END_INDEX: usize = 5;
+/// Index where the message should be written to.
+const MSG_START_INDEX: usize = TS_END_INDEX + 7;
+
+pub(crate) struct Buffer {
+    buf: Vec<u8>,
+    indices: [usize; N_INDICES],
+}
+
+impl Buffer {
+    pub(crate) fn new() -> Buffer {
+        let mut buf = Vec::with_capacity(1024);
+        // Write the parts of output that can be reused.
+        buf.extend_from_slice(REUSABLE_PARTS);
+        let indices = [0; N_INDICES];
+        Buffer { buf, indices }
+    }
+
+    #[inline]
+    #[cfg(feature = "timestamp")]
+    fn write_ts(&mut self) {
+        format_timestamp(&mut self.buf[..TS_END_INDEX]);
+    }
+
+    #[inline]
+    fn ts(&self) -> &[u8] {
+        &self.buf[..TS_END_INDEX]
+    }
+
+    #[inline]
+    fn write_msg(&mut self, args: &fmt::Arguments) {
+        self.buf.truncate(MSG_START_INDEX);
+        // TODO: use `Arguments::as_str` once the `fmt_as_str` feature is
+        // stable.
+        write!(self.buf, "{}", args).unwrap_or_else(|_| unreachable!());
+        self.indices[0] = self.buf.len();
+    }
+
+    #[inline]
+    fn msg(&self) -> &[u8] {
+        // NOTE: not using `MSG_START_INDEX` here because we need to include the
+        // `" msg="` format part.
+        &self.buf[TS_END_INDEX..self.indices[0]]
+    }
+
+    #[inline]
+    fn write_key_values(&mut self, kvs: &dyn kv::Source) {
+        self.buf.extend_from_slice(b"\"");
+        // TODO: see if we can add to the slice of `IoSlice` using the keys
+        // and string values.
+        let mut visitor = KeyValueVisitor(&mut self.buf);
+        kvs.visit(&mut visitor).unwrap_or_else(|_| unreachable!());
+        self.indices[1] = self.buf.len();
+    }
+
+    #[inline]
+    fn key_values(&self) -> &[u8] {
+        &self.buf[self.indices[0]..self.indices[1]]
+    }
+
+    #[inline]
+    fn write_line(&mut self, line: u32) {
+        self.buf.push(b':');
+        let mut itoa = itoa::Buffer::new();
+        self.buf.extend_from_slice(itoa.format(line).as_bytes());
+        self.buf.extend_from_slice(b"\"\n");
+        self.indices[2] = self.buf.len();
+    }
+
+    #[inline]
+    fn line(&self) -> &[u8] {
+        &self.buf[self.indices[1]..self.indices[2]]
+    }
+}
+
+/// Format the timestamp in the following format:
+/// `ts="YYYY-MM-DDThh:mm:ss.SSSSSSZ"`. For example:
+/// `ts="2020-12-31T11:00:01.743357Z"`.
+///
+/// # Notes
+///
+/// The `buf` must come from [`Buffer::ts`] as it only overwrites the date, not
+/// the format.
+#[inline]
+#[cfg(feature = "timestamp")]
+fn format_timestamp(buf: &mut [u8]) {
     use std::mem::MaybeUninit;
     use std::time::{Duration, SystemTime};
 
@@ -74,39 +186,81 @@ fn format_timestamp(buf: &mut Vec<u8>) {
     };
     let micros = diff.subsec_micros();
 
-    write!(
-        buf,
-        "{:004}-{:02}-{:02}T{:02}:{:02}:{:02}.{:06}Z ",
-        year, month, day, hour, min, sec, micros,
-    )
-    .unwrap_or_else(|_| unreachable!());
+    let mut itoa = itoa::Buffer::new();
+    buf[4..8].copy_from_slice(itoa.format(year).as_bytes());
+    zero_pad2(&mut buf[9..11], itoa.format(month).as_bytes());
+    zero_pad2(&mut buf[12..14], itoa.format(day).as_bytes());
+    zero_pad2(&mut buf[15..17], itoa.format(hour).as_bytes());
+    zero_pad2(&mut buf[18..20], itoa.format(min).as_bytes());
+    zero_pad2(&mut buf[21..23], itoa.format(sec).as_bytes());
+    zero_pad6(&mut buf[24..30], itoa.format(micros).as_bytes());
 }
 
-/// Prints key values in ": key1=value1, key2=value2" format.
-///
-/// # Notes
-///
-/// Prints ": " itself, only when there is at least one key value pair.
-struct KeyValuePrinter<'a>(&'a dyn kv::Source);
-
-impl<'a> fmt::Display for KeyValuePrinter<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0
-            .visit(&mut KeyValueVisitor(true, f))
-            .map_err(|_| fmt::Error)
+#[inline]
+#[cfg(feature = "timestamp")]
+fn zero_pad2(buf: &mut [u8], v: &[u8]) {
+    debug_assert_eq!(buf.len(), 2);
+    if v.len() == 1 {
+        buf[0] = b'0';
+        buf[1] = v[0];
+    } else {
+        buf[0] = v[0];
+        buf[1] = v[1];
     }
 }
 
-struct KeyValueVisitor<'a, 'b>(bool, &'a mut fmt::Formatter<'b>);
+#[inline]
+#[cfg(feature = "timestamp")]
+fn zero_pad6(buf: &mut [u8], v: &[u8]) {
+    debug_assert_eq!(buf.len(), 6);
+    let start = 6 - v.len();
+    for i in 0..=start {
+        buf[i] = b'0';
+    }
+    buf[start..6].copy_from_slice(v);
+}
 
-impl<'a, 'b, 'kvs> kv::Visitor<'kvs> for KeyValueVisitor<'a, 'b> {
+/// Formats key value pairs in the following format: `key="value"`. For example:
+/// `user_name="Thomas" user_id=123 is_admin=true`
+struct KeyValueVisitor<'b>(&'b mut Vec<u8>);
+
+impl<'b, 'kvs> kv::Visitor<'kvs> for KeyValueVisitor<'b> {
     fn visit_pair(&mut self, key: kv::Key<'kvs>, value: kv::Value<'kvs>) -> Result<(), kv::Error> {
-        self.1
-            .write_str(if self.0 { ": " } else { ", " })
-            .and_then(|()| {
-                self.0 = false;
-                write!(self.1, "{}={}", key, value)
-            })
-            .map_err(Into::into)
+        self.0.push(b' ');
+        self.0.extend_from_slice(key.as_str().as_bytes());
+        self.0.push(b'=');
+        // TODO: use key-value visitor proposed here:
+        // <https://github.com/rust-lang/log/issues/440>.
+        if let Some(value) = value.to_borrowed_str() {
+            self.0.push(b'\"');
+            self.0.extend_from_slice(value.as_bytes());
+            self.0.push(b'\"');
+        } else if let Some(value) = value.to_u64() {
+            let mut itoa = itoa::Buffer::new();
+            self.0.extend_from_slice(itoa.format(value).as_bytes());
+        } else if let Some(value) = value.to_i64() {
+            let mut itoa = itoa::Buffer::new();
+            self.0.extend_from_slice(itoa.format(value).as_bytes());
+        } else if let Some(value) = value.to_f64() {
+            let mut ryu = ryu::Buffer::new();
+            self.0.extend_from_slice(ryu.format(value).as_bytes());
+        } else if let Some(value) = value.to_bool() {
+            if value {
+                self.0.extend_from_slice(b"true");
+            } else {
+                self.0.extend_from_slice(b"false");
+            }
+        } else if let Some(value) = value.to_char() {
+            self.0.push(b'\"');
+            let mut buf = [0; 4];
+            self.0
+                .extend_from_slice(value.encode_utf8(&mut buf).as_bytes());
+            self.0.push(b'\"');
+        } else {
+            self.0.push(b'\"');
+            write!(self.0, "{}", value).unwrap_or_else(|_| unreachable!());
+            self.0.push(b'\"');
+        }
+        Ok(())
     }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -214,8 +214,8 @@ fn zero_pad2(buf: &mut [u8], v: &[u8]) {
 fn zero_pad6(buf: &mut [u8], v: &[u8]) {
     debug_assert_eq!(buf.len(), 6);
     let start = 6 - v.len();
-    for i in 0..=start {
-        buf[i] = b'0';
+    for b in buf.iter_mut().take(start) {
+        *b = b'0';
     }
     buf[start..6].copy_from_slice(v);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! of the messages to actually log and which to ignore.
 //!
 //! `LOG` and `LOG_LEVEL` can be used to set the severity to a specific value,
-//! see the [`log`]'s package `LevelFilter` type for available values.
+//! see the [`log`]'s package [`LevelFilter`] type for available values.
 //!
 //! ```bash
 //! # In your shell of choose:
@@ -97,22 +97,22 @@
 //! used:
 //!
 //! ```text
-//! timestamp [LOG_LEVEL] target: message
+//! ts="YYYY-MM-DDTHH:MM:SS.MICROSZ" lvl="$LOG_LEVEL" msg="$message" target="$target" module="$module"
 //!
 //! For example:
 //!
-//! 2018-03-24T13:48:28.820588Z [ERROR] my_module: my error message
+//! ts="2018-03-24T13:48:28.820588Z" lvl="ERROR" msg="my error message" target="my_module" module="my_module"
 //! ```
 //!
 //! For requests, logged using the [`REQUEST_TARGET`] target or the [`request`]
 //! macro and printed to standard out, the following format is used:
 //!
 //! ```text
-//! timestamp [REQUEST]: message
+//! ts="YYYY-MM-DDTHH:MM:SS.MICROSZ" lvl="INFO" msg="$message" target="request" module="$module"
 //!
 //! For example:
 //!
-//! 2018-03-24T13:30:28.820588Z [REQUEST]: my request message
+//! ts="2018-03-24T13:30:28.820588Z" lvl="INFO" msg="my request message" target="request" module="my_module"
 //! ```
 //!
 //! Note: the timestamp is not printed when the *timestamp* feature is not
@@ -128,9 +128,8 @@
 //! ## Timestamp feature
 //!
 //! The *timestamp* feature adds a timestamp in front of every message. It uses
-//! the format defined in [`RFC3339`] with 6 digit nanosecond precision, e.g.
-//! `2018-03-24T13:48:48.063934Z`. This means that the timestamp is **always**
-//! logged in UTC.
+//! the format defined in [`RFC3339`] with 6 digit microsecond precision, e.g.
+//! `2018-03-24T13:48:48.063934Z`. The timestamp is **always** logged in UTC.
 //!
 //!
 //! ## Log-panic feature
@@ -141,7 +140,7 @@
 //! example (this example doesn't include a timestamp).
 //!
 //! ```log
-//! [ERROR] panic: thread 'main' panicked at 'oops': examples/panic.rs:24
+//! lvl="ERROR" msg="thread 'main' panicked at 'oops', examples/panic.rs:24" target="panic" module="" backtrace="
 //! stack backtrace:
 //!    0:        0x106ba8f74 - backtrace::backtrace::trace<closure>
 //!                         at backtrace-0.3.2/src/backtrace/mod.rs:42
@@ -160,13 +159,14 @@
 //!    7:        0x106bc6c08 - std::rt::lang_start::h6f338c4ae2d58bbe
 //!                         at src/libstd/rt.rs:61
 //!    8:        0x106b93c29 - main
+//! "
 //! ```
 //!
 //! If the *timestamp* feature is enable the first line of the message will be
 //! prefixed with a timestamp as described in the [Timestamp feature].
 //!
 //!
-//! # Example
+//! # Examples
 //!
 //! ```
 //! # use std::time::Duration;
@@ -224,8 +224,7 @@ mod tests;
 
 /// Target for logging requests.
 ///
-/// The [`request`] macro provides a convenient way to log requests, it better
-/// to use that.
+/// The [`request`] macro provides a convenient way to log requests.
 ///
 /// See the [crate level documentation] for more.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,14 +335,20 @@ fn log_panic(info: &std::panic::PanicInfo<'_>) {
     };
     let backtrace = Backtrace::force_capture();
 
-    log::error!(
-        target: "panic",
-        "thread '{}' panicked at '{}', {}:{}\n{}",
-        thread_name,
-        msg,
-        file,
-        line,
-        backtrace,
+    log::logger().log(
+        &Record::builder()
+            .args(format_args!(
+                // NOTE: we include file in here because it's only logged when
+                // debug severity is enabled.
+                "thread '{}' panicked at '{}', {}:{}",
+                thread_name, msg, file, line
+            ))
+            .level(log::Level::Error)
+            .target("panic")
+            .file(Some(file))
+            .line(Some(line))
+            .key_values(&("backtrace", &backtrace as &dyn std::fmt::Display))
+            .build(),
     );
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,8 +121,10 @@
 //!
 //! # Crate features
 //!
-//! This crate has two features, both of which are enabled by default,
-//! *timestamp* and *log-panic*.
+//! This crate has three features:
+//! * *timestamp*, enabled by default.
+//! * *log-panic*, enabled by default.
+//! * *nightly*, disabled by default.
 //!
 //!
 //! ## Timestamp feature
@@ -164,6 +166,15 @@
 //!
 //! If the *timestamp* feature is enable the first line of the message will be
 //! prefixed with a timestamp as described in the [Timestamp feature].
+//!
+//!
+//! ## Nightly feature
+//!
+//! Enabling this feature enables the crate to use unstable (i.e. nightly-only)
+//! features from the compiler and standard library.
+//!
+//! Currently this is limited to using the [`std::backtrace`] for creating
+//! backtraces, rather than an external library.
 //!
 //!
 //! # Examples

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,20 +1,21 @@
-use std::default::Default;
+use std::io::{IoSlice, Write};
+use std::mem::replace;
+use std::ops::Deref;
 use std::sync::Mutex;
 #[cfg(feature = "timestamp")]
 use std::time::{Duration, SystemTime};
-use std::{env, panic, str};
+use std::{env, fmt, panic, str};
 
 use lazy_static::lazy_static;
-use log::{debug, error, info, trace, warn, LevelFilter};
+use log::{debug, error, info, kv, trace, warn, Level, LevelFilter, Record};
 
 use crate::{
-    get_log_targets, get_max_level, init, request, Targets, LOG_OUTPUT, LOG_OUTPUT_INDEX,
-    REQUEST_TARGET,
+    format, get_log_targets, get_max_level, init, request, Targets, LOG_OUTPUT, REQUEST_TARGET,
 };
 
 /// Macro to create a group of sequential tests.
 macro_rules! sequential_tests {
-    ($(fn $name:ident() $body:block)+) => {
+    ( $(fn $name: ident () $body: block)+ ) => {
         lazy_static! {
             /// A global lock for testing sequentially.
             static ref SEQUENTIAL_TEST_MUTEX: Mutex<()> = Mutex::new(());
@@ -36,7 +37,7 @@ macro_rules! sequential_tests {
 
 sequential_tests! {
     fn should_get_the_correct_log_level_from_env() {
-        let tests = vec![
+        let tests = &[
             ("LOG", "TRACE", LevelFilter::Trace),
             ("LOG", "ERROR", LevelFilter::Error),
             ("LOG_LEVEL", "ERROR", LevelFilter::Error),
@@ -45,31 +46,36 @@ sequential_tests! {
             ("DEBUG", "1", LevelFilter::Debug),
         ];
 
-        for test in tests {
-            env::set_var(test.0, test.1);
+        for (env_var, env_val, want) in tests {
+            env::set_var(env_var, env_val);
 
-            let want = test.2;
             let got = get_max_level();
-            assert_eq!(want, got);
+            assert_eq!(*want, got);
 
-            env::remove_var(test.0);
+            env::remove_var(env_var);
         }
+
+        // Should default to info.
+        env::remove_var("TRACE");
+        env::remove_var("DEBUG");
+        env::remove_var("LOG");
+        env::remove_var("LOG_LEVEL");
+        assert_eq!(get_max_level(), LevelFilter::Info);
     }
 
     fn should_get_correct_log_targets() {
-        let tests = vec![
+        let tests = &[
             ("", Targets::All),
             ("crate1", Targets::Only(vec!["crate1".into()].into_boxed_slice())),
             ("crate1::mod1", Targets::Only(vec!["crate1::mod1".into()].into_boxed_slice())),
             ("crate1,crate2", Targets::Only(vec!["crate1".into(), "crate2".into()].into_boxed_slice())),
         ];
 
-        for test in tests {
-            env::set_var("LOG_TARGET", test.0);
+        for (env_val, want) in tests {
+            env::set_var("LOG_TARGET", env_val);
 
-            let want = test.1;
             let got = get_log_targets();
-            assert_eq!(want, got);
+            assert_eq!(*want, got);
         }
 
         env::remove_var("LOG_TARGET");
@@ -77,7 +83,21 @@ sequential_tests! {
     }
 
     fn log_output() {
-        unsafe { log_setup(); }
+        LOG_OUTPUT.lock().unwrap().clear();
+
+        env::set_var("LOG_LEVEL", "TRACE");
+        init();
+        env::remove_var("LOG_LEVEL");
+
+        let want = &[
+            "lvl=\"TRACE\" msg=\"trace message\" target=\"std_logger::tests\" module=\"std_logger::tests\" file=\"src/tests.rs:105\"\n",
+            "lvl=\"DEBUG\" msg=\"debug message\" target=\"std_logger::tests\" module=\"std_logger::tests\" file=\"src/tests.rs:106\"\n",
+            "lvl=\"INFO\" msg=\"info message\" target=\"std_logger::tests\" module=\"std_logger::tests\" file=\"src/tests.rs:107\"\n",
+            "lvl=\"WARN\" msg=\"warn message\" target=\"std_logger::tests\" module=\"std_logger::tests\" file=\"src/tests.rs:108\"\n",
+            "lvl=\"ERROR\" msg=\"error message\" target=\"std_logger::tests\" module=\"std_logger::tests\" file=\"src/tests.rs:109\"\n",
+            "lvl=\"INFO\" msg=\"request message1\" target=\"request\" module=\"std_logger::tests\" file=\"src/tests.rs:110\"\n",
+            "lvl=\"INFO\" msg=\"request message2\" target=\"request\" module=\"std_logger::tests\" file=\"src/tests.rs:111\"\n",
+        ];
 
         #[cfg(feature = "timestamp")]
         let timestamp = SystemTime::now();
@@ -90,76 +110,32 @@ sequential_tests! {
         info!(target: REQUEST_TARGET, "request message1");
         request!("request message2");
 
-        let want = vec![
-            "[TRACE] std_logger::tests (src/tests.rs:85): trace message",
-            "[DEBUG] std_logger::tests (src/tests.rs:86): debug message",
-            "[INFO] std_logger::tests (src/tests.rs:87): info message",
-            "[WARN] std_logger::tests (src/tests.rs:88): warn message",
-            "[ERROR] std_logger::tests (src/tests.rs:89): error message",
-            "[REQUEST] std_logger::tests (src/tests.rs:90): request message1",
-            "[REQUEST] std_logger::tests (src/tests.rs:91): request message2",
-        ];
-        let mut got = unsafe {
-            (&*LOG_OUTPUT).iter()
-        };
+        let got = replace(&mut *(LOG_OUTPUT.lock().unwrap()), Vec::new());
+        // Make sure the panics aren't logged.
+        let _ = std::panic::take_hook();
 
         let mut got_length = 0;
-        let mut want_iter = want.iter();
-        loop {
-            match (want_iter.next(), got.next()) {
-                (Some(want), Some(got)) if got.is_some() => {
-                    let got = got.as_ref().unwrap();
-                    let got = str::from_utf8(got).expect("unable to parse string").trim();
+        for (want, got) in want.into_iter().zip(got.into_iter()) {
+            let got = str::from_utf8(&got).expect("unable to parse string");
 
-                    #[allow(unused_mut)]
-                    let mut want = (*want).to_owned();
-                    #[cfg(feature = "timestamp")]
-                    { want = add_timestamp(want, timestamp, got); }
+            #[allow(unused_mut)]
+            let mut want = (*want).to_owned();
+            #[cfg(feature = "timestamp")]
+            { want = add_timestamp(want, timestamp, got); }
 
-                    // TODO: for some reason this failure doesn't shows itself in the
-                    // output, hence this workaround.
-                    println!("Comparing:");
-                    println!("want: {}", want);
-                    println!("got:  {}", got);
-                    assert_eq!(got, want.as_str(), "message differ");
-
-                    got_length += 1;
-                },
-                _ => break,
-            }
+            assert_eq!(got, want.as_str(), "message differ");
+            got_length += 1;
         }
 
-        if got_length != want.len() {
-            panic!("the number of log messages got differs from the amount of messages wanted");
-        }
+        assert_eq!(got_length, want.len(), "the number of log messages got differs from the amount of messages wanted");
     }
-}
-
-/// This requires the `SEQUENTIAL_TEST_MUTEX` to be held!
-unsafe fn log_setup() {
-    use std::sync::atomic::Ordering;
-
-    if !LOG_OUTPUT.is_null() {
-        for output in (&mut *LOG_OUTPUT).iter_mut().skip(1) {
-            drop(output.take());
-        }
-        LOG_OUTPUT_INDEX.store(1, Ordering::Relaxed);
-        return;
-    }
-
-    let output = Box::new(Default::default());
-    LOG_OUTPUT = Box::into_raw(output);
-
-    env::set_var("LOG_LEVEL", "TRACE");
-    init();
-    env::remove_var("LOG_LEVEL");
 }
 
 #[cfg(feature = "timestamp")]
-fn add_timestamp(message: String, now: SystemTime, got: &str) -> String {
+fn add_timestamp(message: String, timestamp: SystemTime, got: &str) -> String {
     use std::mem::MaybeUninit;
 
-    let diff = now
+    let diff = timestamp
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap_or(Duration::new(0, 0));
     let mut tm = MaybeUninit::uninit();
@@ -179,21 +155,21 @@ fn add_timestamp(message: String, now: SystemTime, got: &str) -> String {
 
     // Add the timestamp to the expected string.
     let timestamp = format!(
-        "{:004}-{:02}-{:02}T{:02}:{:02}:{:02}.{}Z",
+        "ts=\"{:004}-{:02}-{:02}T{:02}:{:02}:{:02}.{}Z\"",
         year,
         month,
         day,
         hour,
         min,
         sec,
-        &got[20..26] // We can never match the microseconds, so we just copy them.
+        &got[24..30] // We can never match the microseconds, so we just copy them.
     );
     format!("{} {}", timestamp, message)
 }
 
 #[test]
 fn targets_should_log() {
-    let targets = vec![
+    let targets = &[
         Targets::All,
         Targets::Only(vec!["crate1".into()].into_boxed_slice()),
         Targets::Only(vec!["crate1::mod1".into()].into_boxed_slice()),
@@ -219,4 +195,73 @@ fn targets_should_log() {
             )
         }
     }
+}
+
+#[test]
+fn format() {
+    struct MyDisplay;
+
+    impl fmt::Display for MyDisplay {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "MyDisplay")
+        }
+    }
+
+    let record1 = Record::builder()
+        .args(format_args!("some arguments1"))
+        .level(Level::Info)
+        .target("some_target1")
+        .module_path_static(Some("module_path1"))
+        .file_static(Some("file1"))
+        .line(Some(123))
+        .key_values(&("key1", "value1"))
+        .build();
+    let kvs = &[
+        ("key2a", (&"value2") as &dyn kv::ToValue),
+        ("key2b", &123u64),
+        ("key3c", &-123i64),
+        ("key3d", &123.0f64),
+        ("key2e", &true),
+        ("key2f", &false),
+        ("key2g", &'c'),
+        ("key2g", &(&MyDisplay as &dyn fmt::Display)),
+    ];
+    let kvs: &[(&str, &dyn kv::ToValue)] = kvs.deref();
+    let kvs: &dyn kv::Source = &kvs;
+    let record2 = Record::builder()
+        .args(format_args!("arguments2"))
+        .level(Level::Error)
+        .target("second_target")
+        .module_path_static(Some("module_path1"))
+        .file_static(Some("file2"))
+        .line(Some(111))
+        .key_values(kvs)
+        .build();
+
+    let tests = &[
+        (record1.clone(), true, "lvl=\"INFO\" msg=\"some arguments1\" target=\"some_target1\" module=\"module_path1\" key1=\"value1\" file=\"file1:123\"\n"),
+        (record1, false, "lvl=\"INFO\" msg=\"some arguments1\" target=\"some_target1\" module=\"module_path1\" key1=\"value1\"\n"),
+        (record2, true, "lvl=\"ERROR\" msg=\"arguments2\" target=\"second_target\" module=\"module_path1\" key2a=\"value2\" key2b=123 key3c=-123 key3d=123.0 key2e=true key2f=false key2g=\"c\" key2g=\"MyDisplay\" file=\"file2:111\"\n"),
+    ];
+
+    for (record, debug, want) in tests {
+        let got = format_record(record, *debug);
+        #[allow(unused_mut)]
+        let mut want = (*want).to_owned();
+        #[cfg(feature = "timestamp")]
+        {
+            want = add_timestamp(want, SystemTime::now(), &got)
+        }
+
+        assert_eq!(got, *want);
+    }
+}
+
+fn format_record(record: &Record, debug: bool) -> String {
+    let mut bufs = [IoSlice::new(&[]); crate::BUFS_SIZE];
+    let mut buf = format::Buffer::new();
+    let bufs = format::record(&mut bufs, &mut buf, record, debug);
+    let mut output = Vec::new();
+    let _ = output.write_vectored(bufs).unwrap();
+    String::from_utf8(output).unwrap()
 }


### PR DESCRIPTION
The logfmt doesn't really have a standard, but it is described here:
https://www.brandur.org/logfmt, along with its best practices.

The new implementation uses vectored writing, reducing the amount of
copying when formatting the log record.

TODO:
* [ ] Use vectored I/O in key-values of the record.
* [ ] Benchmark copying into a single buffer vs. using more vectored I/O. I.e. at what point is copying *x* bytes cheaper than using another `iovec`.