### PR TITLE
update log to use kv_unstable_std instead of std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ log-panic = ["log-panics"]
 timestamp = ["chrono"]
 
 [dependencies]
-log        = { version = "0.4.11", default-features = false, features = ["std", "kv_unstable"] }
+log        = { version = "0.4.13", default-features = false, features = ["kv_unstable_std"] }
 # Required by timestamp feature.
 chrono     = { version = "0.4.15", optional = true, default-features = false, features = ["clock"] }
 # Required by log-panic feature.


### PR DESCRIPTION
Part of https://github.com/rust-lang/log/issues/437

The `log` crate has an unstable structured logging API under the `kv_unstable` feature. In previous releases, if you specified both the `kv_unstable` and `std` features of `log` like so:

```toml
log = { features = ["std", "kv_unstable"]}
```

you'd get support for standard library types in `log`'s structured logging API.

Going forward, this functionality is now gated under `kv_unstable_std`:

```toml
log = { features = ["kv_unstable_std"]}
```

This change was made because we need to enable features in optional dependencies when both the `std` and `kv_unstable` features are enabled, which isn't currently supported by Cargo.

This PR updates this library to follow the new approach. It can be merged at any time and is currently non-blocking, but on 2020-01-18 the version of `log` requiring `kv_unstable_std` instead of `kv_unstable` and `std` will be published.

Thanks for trying out `log`'s structured logging API and sorry for any disruption! :bow: