### PR TITLE
Implement log-panic feature using std::backtrace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ default   = ["timestamp", "log-panic"]
 log-panic = ["log-panics"]
 timestamp = ["chrono"]
 
+# Enable use of features only available in nightly compiler.
+nightly  = []
+
 [dependencies]
 log        = { version = "0.4.11", default-features = false, features = ["std", "kv_unstable"] }
 # Required by timestamp feature.

--- a/examples/key_value.rs
+++ b/examples/key_value.rs
@@ -35,11 +35,11 @@ fn logger_middleware(request: Request) -> Response {
 
     log::info!("Hello world");
 
-    let kvs: Vec<Box<dyn log::kv::Source>> = vec![
-            Box::new(("url", &url)),
-            Box::new(("method", &method)),
-            Box::new(("status_code", response.status_code)),
-            Box::new(("body_size", response.body.len() as u64)),
+    let kvs: &[(&str, &dyn log::kv::ToValue)] = &[
+        ("url", &&*url), // `String` -> `&&str` -> `&dyn ToValue`.
+        ("method", &&*method),
+        ("status_code", &response.status_code),
+        ("body_size", &response.body.len()),
     ];
 
     let record = log::Record::builder()


### PR DESCRIPTION
This adds a `nightly` feature to allow us to experiment with nightly features of the compiler/std lib.