### PR TITLE
Use libc::gmtime_r for time formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-/target/
-**/*.rs.bk
+target/
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,15 +22,15 @@ appveyor  = { repository = "Thomasdezeeuw/std-logger", service = "github" }
 [features]
 default   = ["timestamp", "log-panic"]
 log-panic = ["log-panics"]
-timestamp = ["chrono"]
+timestamp = ["libc"]
 
 # Enable use of features only available in nightly compiler.
 nightly  = []
 
 [dependencies]
-log        = { version = "0.4.13", default-features = false, features = ["kv_unstable_std"] }
+log        = { version = "0.4.14", default-features = false, features = ["kv_unstable_std"] }
 # Required by timestamp feature.
-chrono     = { version = "0.4.15", optional = true, default-features = false, features = ["clock"] }
+libc       = { version = "0.2.86", optional = true, default-features = false }
 # Required by log-panic feature.
 log-panics = { version = "2.0.0", optional = true, default-features = false, features = ["with-backtrace"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,16 +35,7 @@ chrono     = { version = "0.4.15", optional = true, default-features = false, fe
 log-panics = { version = "2.0.0", optional = true, default-features = false, features = ["with-backtrace"] }
 
 [dev-dependencies]
-criterion   = "0.2"
 lazy_static = "1.0"
-libc        = "0.2"
 
-[[bench]]
-name = "time_format"
-path = "benches/time_format.rs"
-harness = false
-
-[[bench]]
-name = "standard_out"
-path = "benches/standard_out.rs"
-harness = false
+[workspace]
+members = ["benches"]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name          = "std-logger-benchmarks"
+version       = "0.0.0"
+authors       = ["Thomas de Zeeuw <thomasdezeeuw@gmail.com>"]
+edition       = "2018"
+
+[dependencies]
+chrono      = "0.4.19"
+criterion   = "0.3.4"
+libc        = "0.2.86"
+log         = "0.4.14"
+
+[[bench]]
+name = "time_format"
+path = "time_format.rs"
+harness = false
+
+[[bench]]
+name = "standard_out"
+path = "standard_out.rs"
+harness = false

--- a/benches/time_format.rs
+++ b/benches/time_format.rs
@@ -24,10 +24,15 @@ fn chrono_format(c: &mut Criterion) {
 
     c.bench_function("chrono format", |b| {
         let timestamp = chrono::Utc::now();
+        let mut out = String::new();
         b.iter(|| {
-            format!("{} [{}] {}: {}\n",
+            out = format!(
+                "{} [{}] {}: {}\n",
                 timestamp.format_with_items(FORMAT_ITEMS.iter().cloned()),
-                "INFO", "target", "Some message");
+                "INFO",
+                "target",
+                "Some message"
+            );
         })
     });
 }
@@ -37,14 +42,60 @@ fn manual_format(c: &mut Criterion) {
 
     c.bench_function("manual format", |b| {
         let timestamp = chrono::Utc::now();
+        let mut out = String::new();
         b.iter(|| {
-            format!("{:004}-{:02}-{:02}T{:02}:{:02}:{:02}.{:06}Z [{}] {}: {}\n",
-            timestamp.year(), timestamp.month(), timestamp.day(),
-            timestamp.hour(), timestamp.minute(), timestamp.second(),
-            timestamp.nanosecond(), "INFO", "target", "Some message");
+            out = format!(
+                "{:004}-{:02}-{:02}T{:02}:{:02}:{:02}.{:06}Z [{}] {}: {}\n",
+                timestamp.year(),
+                timestamp.month(),
+                timestamp.day(),
+                timestamp.hour(),
+                timestamp.minute(),
+                timestamp.second(),
+                timestamp.nanosecond(),
+                "INFO",
+                "target",
+                "Some message"
+            );
         })
     });
 }
 
-criterion_group!(time_format, chrono_format, manual_format);
+fn libc_format(c: &mut Criterion) {
+    use std::mem::MaybeUninit;
+    use std::time::{Duration, SystemTime};
+
+    c.bench_function("libc format", |b| {
+        let now = SystemTime::now();
+        let diff = now
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or(Duration::new(0, 0));
+
+        let mut out = String::new();
+        b.iter(|| {
+            let mut tm = MaybeUninit::uninit();
+            let secs_since_epoch = diff.as_secs() as i64;
+            let tm = unsafe { libc::gmtime_r(&secs_since_epoch, tm.as_mut_ptr()) };
+            let (year, month, day, hour, min, sec) = match unsafe { tm.as_ref() } {
+                Some(tm) => (
+                    tm.tm_year + 1900,
+                    tm.tm_mon + 1,
+                    tm.tm_mday,
+                    tm.tm_hour,
+                    tm.tm_min,
+                    tm.tm_sec,
+                ),
+                None => (0, 0, 0, 0, 0, 0),
+            };
+            let nanos = diff.subsec_nanos();
+
+            out = format!(
+                "{:004}-{:02}-{:02}T{:02}:{:02}:{:02}.{:06}Z [{}] {}: {}\n",
+                year, month, day, hour, min, sec, nanos, "INFO", "target", "Some message"
+            );
+        })
+    });
+}
+
+criterion_group!(time_format, chrono_format, manual_format, libc_format);
 criterion_main!(time_format);


### PR DESCRIPTION
According to the benchmarks formatting via `gmtime(3)` is roughly 10%
faster than using Chrono. This allows us to drop Chrono as a dependency.