### PR TITLE
Correctly handle panics during logging

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -110,9 +110,9 @@ sequential_tests! {
         info!(target: REQUEST_TARGET, "request message1");
         request!("request message2");
 
-        let got = replace(&mut *(LOG_OUTPUT.lock().unwrap()), Vec::new());
         // Make sure the panics aren't logged.
         let _ = std::panic::take_hook();
+        let got = replace(&mut *(LOG_OUTPUT.lock().unwrap()), Vec::new());
 
         let mut got_length = 0;
         for (want, got) in want.into_iter().zip(got.into_iter()) {

--- a/tests/regression_42.rs
+++ b/tests/regression_42.rs
@@ -1,0 +1,24 @@
+//! Regression test for issue #42.
+
+#![cfg(feature = "log-panic")]
+
+use std::fmt;
+
+use log::info;
+
+/// Panicking while logging triggers another `log!`.
+#[test]
+#[should_panic = "panic during formatting"]
+fn panicking_while_logging() {
+    std_logger::init();
+
+    struct T;
+
+    impl fmt::Display for T {
+        fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+            panic!("panic during formatting")
+        }
+    }
+
+    info!("{}", T);
+}


### PR DESCRIPTION
Previously when a panic occurred during the formatting/logging of a
record, and with the log-panic feature enabled, it would log again. This
meant that the log function would be called again, but this time the BUF
thread-local was in use. Trying to borrow this thread-local again would
panic as shown in issue 42. The following code was enough to trigger the
bug.

    struct T;

    impl fmt::Display for T {
        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
            panic!()
        }
    }

    info!("T: {}", T);

This commit fixes the problem by allocating a new buffer in the rare
case this happens.

Closes #42.