### PR TITLE
Remove libc dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ edition       = "2018"
 [features]
 default   = ["timestamp", "log-panic"]
 log-panic = ["log-panics"]
-timestamp = ["libc"]
+timestamp = []
 
 # Enable use of features only available in nightly compiler.
 nightly  = []
@@ -28,13 +28,12 @@ nightly  = []
 log        = { version = "0.4.14", default-features = false, features = ["kv_unstable_std"] }
 itoa       = { version = "0.4.7", default-features = false }
 ryu        = { version = "1.0.5", default-features = false }
-# Required by timestamp feature.
-libc       = { version = "0.2.86", optional = true, default-features = false }
 # Required by log-panic feature.
 log-panics = { version = "2.0.0", optional = true, default-features = false, features = ["with-backtrace"] }
 
 [dev-dependencies]
 lazy_static = "1.0"
+libc        = { version = "0.2.86", default-features = false }
 
 [workspace]
 members = ["benches", "parser"]

--- a/src/format.rs
+++ b/src/format.rs
@@ -167,38 +167,15 @@ impl Buffer {
 #[inline]
 #[cfg(feature = "timestamp")]
 fn format_timestamp(buf: &mut [u8]) {
-    use std::mem::MaybeUninit;
-    use std::time::{Duration, SystemTime};
-
-    let now = SystemTime::now();
-    let diff = now
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_else(|_| Duration::new(0, 0));
-
-    let mut tm = MaybeUninit::uninit();
-    let secs_since_epoch = diff.as_secs() as i64;
-    let tm = unsafe { libc::gmtime_r(&secs_since_epoch, tm.as_mut_ptr()) };
-    let (year, month, day, hour, min, sec) = match unsafe { tm.as_ref() } {
-        Some(tm) => (
-            tm.tm_year + 1900,
-            tm.tm_mon + 1,
-            tm.tm_mday,
-            tm.tm_hour,
-            tm.tm_min,
-            tm.tm_sec,
-        ),
-        None => (0, 0, 0, 0, 0, 0),
-    };
-    let micros = diff.subsec_micros();
-
+    let timestamp = crate::timestamp::Timestamp::now();
     let mut itoa = itoa::Buffer::new();
-    buf[4..8].copy_from_slice(itoa.format(year).as_bytes());
-    zero_pad2(&mut buf[9..11], itoa.format(month).as_bytes());
-    zero_pad2(&mut buf[12..14], itoa.format(day).as_bytes());
-    zero_pad2(&mut buf[15..17], itoa.format(hour).as_bytes());
-    zero_pad2(&mut buf[18..20], itoa.format(min).as_bytes());
-    zero_pad2(&mut buf[21..23], itoa.format(sec).as_bytes());
-    zero_pad6(&mut buf[24..30], itoa.format(micros).as_bytes());
+    buf[4..8].copy_from_slice(itoa.format(timestamp.year).as_bytes());
+    zero_pad2(&mut buf[9..11], itoa.format(timestamp.month).as_bytes());
+    zero_pad2(&mut buf[12..14], itoa.format(timestamp.day).as_bytes());
+    zero_pad2(&mut buf[15..17], itoa.format(timestamp.hour).as_bytes());
+    zero_pad2(&mut buf[18..20], itoa.format(timestamp.min).as_bytes());
+    zero_pad2(&mut buf[21..23], itoa.format(timestamp.sec).as_bytes());
+    zero_pad6(&mut buf[24..30], itoa.format(timestamp.micro).as_bytes());
 }
 
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,6 +240,9 @@ use log::{LevelFilter, Log, Metadata, Record, SetLoggerError};
 mod format;
 use format::{Buffer, BUFS_SIZE};
 
+#[cfg(feature = "timestamp")]
+mod timestamp;
+
 #[cfg(test)]
 mod tests;
 

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1,0 +1,92 @@
+use std::time::{Duration, SystemTime};
+
+/// Timstamp for humans.
+pub(crate) struct Timestamp {
+    pub(crate) year: u16,
+    pub(crate) month: u8,
+    pub(crate) day: u8,
+    pub(crate) hour: u8,
+    pub(crate) min: u8,
+    pub(crate) sec: u8,
+    pub(crate) micro: u32,
+}
+
+#[cfg(feature = "timestamp")]
+impl Timestamp {
+    pub(crate) fn now() -> Timestamp {
+        Timestamp::from(SystemTime::now())
+    }
+
+    /// # Notes
+    ///
+    /// This only works for days later then 2001.
+    // NOTE: pub for testing.
+    pub(crate) fn from(time: SystemTime) -> Timestamp {
+        // Ported from musl, original source:
+        // <https://git.musl-libc.org/cgit/musl/tree/src/time/__secs_to_tm.c>.
+
+        /// 2000-03-01 (mod 400 year, immediately after feb29).
+        const LEAPOCH: u64 = 946684800 + 86400 * (31 + 29);
+        const DAYS_PER_400Y: u64 = 365 * 400 + 97;
+        const DAYS_PER_100Y: u64 = 365 * 100 + 24;
+        const DAYS_PER_4Y: u64 = 365 * 4 + 1;
+        const DAYS_IN_MONTH: [u64; 12] = [31, 30, 31, 30, 31, 31, 30, 31, 30, 31, 31, 29];
+
+        let diff = time
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_else(|_| Duration::new(0, 0));
+        let secs_since_epoch = diff.as_secs();
+
+        let secs = secs_since_epoch - LEAPOCH;
+        let days = secs / 86400;
+        let remsecs = secs % 86400;
+
+        let qc_cycles = days / DAYS_PER_400Y;
+        let mut remdays = days % DAYS_PER_400Y;
+
+        let mut c_cycles = remdays / DAYS_PER_100Y;
+        if c_cycles == 4 {
+            c_cycles -= 1;
+        }
+        remdays -= c_cycles * DAYS_PER_100Y;
+
+        let mut q_cycles = remdays / DAYS_PER_4Y;
+        if q_cycles == 25 {
+            q_cycles -= 1;
+        }
+        remdays -= q_cycles * DAYS_PER_4Y;
+
+        let mut remyears = remdays / 365;
+        if remyears == 4 {
+            remyears -= 1
+        }
+        remdays -= remyears * 365;
+
+        let mut year = remyears + (4 * q_cycles) + (100 * c_cycles) + (400 * qc_cycles);
+
+        // Determine the month of the year based on the remaining days
+        // (`remdays`).
+        let mut month = 0;
+        for days_in_month in DAYS_IN_MONTH {
+            if days_in_month > remdays {
+                break;
+            }
+            remdays -= days_in_month;
+            month += 1;
+        }
+        if month >= 10 {
+            month -= 12;
+            year += 1;
+        }
+
+        Timestamp {
+            year: (year + 100 + 1900) as u16,
+            month: (month + 2 + 1) as u8,
+            day: (remdays + 1) as u8,
+            hour: (remsecs / 3600) as u8,
+            min: (remsecs / 60 % 60) as u8,
+            sec: (remsecs % 60) as u8,
+            micro: diff.subsec_micros(),
+        }
+    }
+}


### PR DESCRIPTION
We only used gmtime_r which I've now ported over from musl libc. The
port is very straight forward so I don't expect any bugs. However just
in case I've added a test that compare is to the libc implementation.