### PR TITLE
Add Config::with_call_location

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,7 @@ use crate::{Logger, Targets};
 #[derive(Debug)]
 pub struct Config<F, Kvs> {
     filter: LevelFilter,
+    add_loc: Option<bool>,
     targets: Targets,
     kvs: Kvs,
     _format: PhantomData<F>,
@@ -44,6 +45,7 @@ where
     fn new(kvs: Kvs) -> Config<F, Kvs> {
         Config {
             filter: get_max_level(),
+            add_loc: None,
             targets: get_log_targets(),
             kvs,
             _format: PhantomData,
@@ -57,8 +59,22 @@ where
     {
         Config {
             filter: self.filter,
+            add_loc: self.add_loc,
             targets: self.targets,
             kvs,
+            _format: self._format,
+        }
+    }
+
+    /// Enable or disable logging of the call location.
+    ///
+    /// Default to enable if the debug (or lower) messages are enabled.
+    pub fn with_call_location(self, enable: bool) -> Config<F, Kvs> {
+        Config {
+            filter: self.filter,
+            add_loc: Some(enable),
+            targets: self.targets,
+            kvs: self.kvs,
             _format: self._format,
         }
     }
@@ -88,6 +104,7 @@ where
     pub fn try_init(self) -> Result<(), SetLoggerError> {
         let logger = Box::new(Logger {
             filter: self.filter,
+            add_loc: self.add_loc.unwrap_or(self.filter >= LevelFilter::Debug),
             targets: self.targets,
             kvs: self.kvs,
             _format: self._format,

--- a/src/format/gcloud.rs
+++ b/src/format/gcloud.rs
@@ -23,7 +23,7 @@ impl Format for Gcloud {
         buf: &'b mut Buffer,
         record: &'b Record,
         kvs: &Kvs,
-        debug: bool,
+        add_loc: bool,
     ) -> &'b [IoSlice<'b>] {
         // Write all parts of the buffer that need formatting.
         buf.buf[0] = b'{';
@@ -31,7 +31,7 @@ impl Format for Gcloud {
         write_timestamp(buf);
         write_msg(buf, record.args());
         write_key_values(buf, record.key_values(), kvs);
-        if debug {
+        if add_loc {
             write_line(buf, record.line().unwrap_or(0));
         }
 
@@ -61,7 +61,7 @@ impl Format for Gcloud {
         // Optional file, e.g.
         // `","sourceLocation":{"file":"some_file.rs","line":"123"}}`, and a line
         // end.
-        let n = if debug {
+        let n = if add_loc {
             bufs[10] = IoSlice::new(b",\"sourceLocation\":{\"file\":\"");
             bufs[11] = IoSlice::new(record.file().unwrap_or("??").as_bytes());
             bufs[12] = IoSlice::new(b"\",\"line\":\"");

--- a/src/format/logfmt.rs
+++ b/src/format/logfmt.rs
@@ -21,14 +21,14 @@ impl Format for LogFmt {
         buf: &'b mut Buffer,
         record: &'b Record,
         kvs: &Kvs,
-        debug: bool,
+        add_loc: bool,
     ) -> &'b [IoSlice<'b>] {
         // Write all parts of the buffer that need formatting.
         #[cfg(feature = "timestamp")]
         write_timestamp(buf);
         write_msg(buf, record.args());
         write_key_values(buf, record.key_values(), kvs);
-        if debug {
+        if add_loc {
             write_line(buf, record.line().unwrap_or(0));
         }
 
@@ -51,7 +51,7 @@ impl Format for LogFmt {
         // Any key value pairs supplied by the user.
         bufs[9] = IoSlice::new(key_values(buf));
         // Optional file, e.g. ` file="some_file:123"`, and a line end.
-        let n = if debug {
+        let n = if add_loc {
             bufs[10] = IoSlice::new(b" file=\"");
             bufs[11] = IoSlice::new(record.file().unwrap_or("??").as_bytes());
             bufs[12] = IoSlice::new(line(buf));

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -16,13 +16,13 @@ pub trait Format {
     /// it resets itself. The returned slices is based on `bufs`, which is used
     /// to order the writable buffers.
     ///
-    /// If `debug` is `true` the file and line are added.
+    /// If `add_loc` is `true` the file and line are added.
     fn format<'b, Kvs: kv::Source>(
         bufs: &'b mut [IoSlice<'b>; BUFS_SIZE],
         buf: &'b mut Buffer,
         record: &'b Record,
         kvs: &Kvs,
-        debug: bool,
+        add_loc: bool,
     ) -> &'b [IoSlice<'b>];
 }
 


### PR DESCRIPTION
Enables or disables logging of the call location.

We keep the default of enabling it only if debug (or lower) messages are enabled.

Closes  #61