### PR TITLE
Escape string values in logfmt

### DIFF
--- a/src/format/logfmt.rs
+++ b/src/format/logfmt.rs
@@ -199,7 +199,9 @@ impl<'b, 'v> VisitValue<'v> for KeyValueVisitor<'b> {
 
     fn visit_str(&mut self, value: &str) -> Result<(), kv::Error> {
         self.0.push(b'\"');
-        Buf(self.0).write_str(value);
+        Buf(self.0)
+            .write_str(value)
+            .unwrap_or_else(|_| unreachable!());
         self.0.push(b'\"');
         Ok(())
     }

--- a/src/format/logfmt.rs
+++ b/src/format/logfmt.rs
@@ -199,7 +199,7 @@ impl<'b, 'v> VisitValue<'v> for KeyValueVisitor<'b> {
 
     fn visit_str(&mut self, value: &str) -> Result<(), kv::Error> {
         self.0.push(b'\"');
-        Buf(self.0).extend_from_slice(value.as_bytes());
+        Buf(self.0).write_str(value);
         self.0.push(b'\"');
         Ok(())
     }


### PR DESCRIPTION
I noticed that a string-valued KV (containing a newline) that I logged ended up broken across two lines, even though it was quoted. I'm guessing the intent was to have it escaped. Alternatively, `fn visit_str` could be removed entirely as `fn visit_any` would (I think?) have the same effect.