### PR TITLE
Add serde1 feature for json and gcloud formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,15 +21,18 @@ autobenches = false
 default   = ["timestamp", "log-panic"]
 log-panic = []
 timestamp = []
+serde1    = ["serde", "log/kv_serde"]
 nightly   = []
 
 [dependencies]
 log        = { version = "0.4.21", default-features = false, features = ["kv_std"] }
 itoa       = { version = "1.0.1", default-features = false }
 ryu        = { version = "1.0.5", default-features = false }
+serde      = { version = "1",     default-features = false, optional = true }
 
 [dev-dependencies]
 libc       = { version = "0.2.86", default-features = false }
+serde      = { version = "1",      default-features = false, features = ["derive"] }
 
 [workspace]
 members = ["benches", "parser"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,6 +180,7 @@
 //! * *timestamp*, enabled by default.
 //! * *log-panic*, enabled by default.
 //! * *nightly*, disabled by default.
+//! * *serde1*, disabled by default.
 //!
 //!
 //! ## Timestamp feature
@@ -238,6 +239,12 @@
 //!
 //! Currently this enables nothing.
 //!
+//! ## Serde1 feature
+//!
+//! Enables the use of [serde] version 1. Mainly this allows the value of
+//! key-value pairs to be structured.
+//!
+//! [serde]: https://crates.io/crates/serde
 //!
 //! # Examples
 //!


### PR DESCRIPTION
The new serde1 feature uses serde::Serializer when serialising the key-value pairs to support complex value.

Closes #76